### PR TITLE
Set default width of all input and combo boxes to 200

### DIFF
--- a/src/main/java/de/fzi/ros_as_a_service/impl/ValueNodeEditor.java
+++ b/src/main/java/de/fzi/ros_as_a_service/impl/ValueNodeEditor.java
@@ -81,12 +81,12 @@ class ValueNodeEditor extends AbstractCellEditor implements TreeCellEditor {
     variableCollection.toArray(variables);
     Arrays.sort(variables, VariableComparator);
     textfield = new JTextField();
-    textfield.setPreferredSize(new Dimension(150, 30));
+    textfield.setPreferredSize(new Dimension(200, 30));
     textfield.setMaximumSize(textfield.getPreferredSize());
     label.setLabelFor(textfield);
     variableCheckbox = new JCheckBox();
     variableCheckbox.setText("Use variable");
-    variableCombobox.setPreferredSize(new Dimension(100, 30));
+    variableCombobox.setPreferredSize(new Dimension(200, 30));
     variableCombobox.addItem("");
     for (int i = 0; i < variables.length; i++) {
       variableCombobox.addItem(variables[i].getDisplayName());

--- a/src/main/java/de/fzi/ros_as_a_service/impl/ValueNodeRenderer.java
+++ b/src/main/java/de/fzi/ros_as_a_service/impl/ValueNodeRenderer.java
@@ -69,7 +69,7 @@ class ValueNodeRenderer implements TreeCellRenderer {
     switch (datadirection) {
       case INPUT:
         label.setLabelFor(variableCombobox);
-        variableCombobox.setPreferredSize(new Dimension(100, 30));
+        variableCombobox.setPreferredSize(new Dimension(200, 30));
         variableCombobox.addItem("");
         for (int i = 0; i < variables.length; i++) {
           variableCombobox.addItem(variables[i].getDisplayName());
@@ -80,12 +80,12 @@ class ValueNodeRenderer implements TreeCellRenderer {
       case OUTPUT:
       default:
         textfield = new JTextField();
-        textfield.setPreferredSize(new Dimension(150, 30));
+        textfield.setPreferredSize(new Dimension(200, 30));
         textfield.setMaximumSize(textfield.getPreferredSize());
         label.setLabelFor(textfield);
         variableCheckbox = new JCheckBox();
         variableCheckbox.setText("Use variable");
-        variableCombobox.setPreferredSize(new Dimension(100, 30));
+        variableCombobox.setPreferredSize(new Dimension(200, 30));
         variableCombobox.addItem("");
         for (int i = 0; i < variables.length; i++) {
           variableCombobox.addItem(variables[i].getDisplayName());


### PR DESCRIPTION
This should improve readability of variable names.