### PR TITLE
Always use `to_str()` in urscriptify

### DIFF
--- a/src/main/java/de/fzi/ros_as_a_service/impl/RosTaskProgramSuperNodeContribution.java
+++ b/src/main/java/de/fzi/ros_as_a_service/impl/RosTaskProgramSuperNodeContribution.java
@@ -743,7 +743,7 @@ public abstract class RosTaskProgramSuperNodeContribution implements ProgramNode
     // replace string variables
     result = result.replaceAll(
         "\\{\\\" \\+ quote \\+ \\\"-\\+useVar\\+-\\\" \\+ quote \\+ \\\":\\\" \\+ quote \\+ \\\"([^\\\"]*)\\\" \\+ quote \\+ \\\"\\}",
-        "\\\" + quote + $1 + quote + \\\"");
+        "\\\" + quote + to_str($1) + quote + \\\"");
     // System.out.println("without useVar : " + result);
 
     // replace numeric variables


### PR DESCRIPTION
If the target variable (on rosbridge side) is a non-numeric variable, always use `to_str()`
when creating the json string. This won't harm if we use a string to store inside
the string but it will enable storing integer values as strings.

Whether it will be treated as string or numeric value on the rosbridge side / json interpreter
is only determined by the fact, whether it has surrounding quotes or not.

Fixes #1 